### PR TITLE
Fix endless loop in completion solving procedure of torrent downloader

### DIFF
--- a/TX/Core/Models/Progresses/BaseMeasurableProgress.cs
+++ b/TX/Core/Models/Progresses/BaseMeasurableProgress.cs
@@ -39,5 +39,10 @@ namespace TX.Core.Models.Progresses
         public long TotalSize { get; private set; }
 
         public float Progress => ((float)DownloadedSize) / TotalSize;
+
+        /// <summary>
+        /// If the downloading is completed.
+        /// </summary>
+        public bool IsCompleted => DownloadedSize.Equals(TotalSize);
     }
 }

--- a/TX/Core/Models/Sources/MagnetSource.cs
+++ b/TX/Core/Models/Sources/MagnetSource.cs
@@ -11,7 +11,7 @@ using System.Threading;
 
 namespace TX.Core.Models.Sources
 {
-    class MagnetSource : AbstractSource, ISingleTargetExtracted
+    class MagnetSource : AbstractSource, ISingleSubsourceExtracted
     {
         public MagnetSource(Uri uri, ClientEngine engine, IEnumerable<string> announceUrls) : base(uri)
         {
@@ -23,16 +23,14 @@ namespace TX.Core.Models.Sources
             link = MagnetLink.FromUri(Uri);
         }
 
-        public async Task<AbstractTarget> GetTargetAsync()
+        public async Task<AbstractSource> GetSubsourceAsync()
         {
             if (!link.AnnounceUrls.IsReadOnly)
                 foreach (var url in announceUrls)
                     link.AnnounceUrls.Add(url);
             CancellationTokenSource ctk = new CancellationTokenSource(TimeSpan.FromMinutes(5));
             var metaData = await engine.DownloadMetadataAsync(link, ctk.Token);
-            var torrent = Torrent.Load(metaData);
-            return new TorrentTarget(metaData, Uri, 
-                torrent.Files.Select(file => file.Path).ToArray());
+            return new TorrentSource(Uri, metaData);
         }
 
         private readonly MagnetLink link = null;

--- a/TX/Core/Models/Targets/TorrentTarget.cs
+++ b/TX/Core/Models/Targets/TorrentTarget.cs
@@ -15,13 +15,13 @@ namespace TX.Core.Models.Targets
 {
     public class TorrentTarget : AbstractTarget
     {
-        public TorrentTarget(byte[] torrentBytes, Uri torrentFileUri, string[] selectedFilePaths)
+        public TorrentTarget(byte[] torrentBytes, Uri displayedUri, string[] selectedFilePaths)
         {
             Ensure.That(torrentBytes, nameof(torrentBytes)).IsNotNull();
             Ensure.That(selectedFilePaths, nameof(selectedFilePaths)).IsNotNull();
-            Ensure.That(torrentFileUri, nameof(torrentFileUri)).IsNotNull();
+            Ensure.That(displayedUri, nameof(displayedUri)).IsNotNull();
 
-            TorrentFileUri = torrentFileUri;
+            DisplayedUri = displayedUri;
             Torrent = Torrent.Load(torrentBytes);
 
             this.torrentBytes = torrentBytes;
@@ -35,7 +35,7 @@ namespace TX.Core.Models.Targets
         [JsonIgnore]
         public Torrent Torrent { get; private set; }
 
-        public Uri TorrentFileUri { get; private set; }
+        public Uri DisplayedUri { get; private set; }
 
         protected override string GetSuggestedName() => Torrent.Name;
 

--- a/TX/Core/Utils/StorageUtils.cs
+++ b/TX/Core/Utils/StorageUtils.cs
@@ -10,7 +10,7 @@ namespace TX.Core.Utils
 {
     public static class StorageUtils
     {
-        public static async Task MoveContentToAsync(this IStorageFolder now, IStorageFolder destination)
+        public static async Task CopyContentToAsync(this IStorageFolder now, IStorageFolder destination)
         {
             var files = await now.GetFilesAsync();
             foreach (var file in files)
@@ -23,10 +23,8 @@ namespace TX.Core.Utils
             {
                 var nowDes = await destination.CreateFolderAsync(folder.Name, 
                     CreationCollisionOption.GenerateUniqueName);
-                await now.MoveContentToAsync(nowDes);
+                await folder.CopyContentToAsync(nowDes);
             }
-
-            await now.DeleteAsync();
         }
 
         public static async Task<IStorageItem> GetStorageItemAsync(string path)

--- a/TX/TaskDetailPage.xaml.cs
+++ b/TX/TaskDetailPage.xaml.cs
@@ -48,7 +48,7 @@ namespace TX
             if (downloader.DownloadTask.Target is HttpTarget httpTarget)
                 TaskHyperlink.Text = httpTarget.Uri.ToString();
             else if (downloader.DownloadTask.Target is TorrentTarget torrentTarget)
-                TaskHyperlink.Text = torrentTarget.TorrentFileUri.ToString();
+                TaskHyperlink.Text = torrentTarget.DisplayedUri.ToString();
 
             DisposeButton.IsEnabled = true;
             Downloader.StatusChanged += StatusChanged;


### PR DESCRIPTION
An error occurs causing endless loops when moving content from the cache folder to the destination folder. This might have fixed the crashing and errors mentioned in #33.