### PR TITLE
Switch database encoding from ASCII to UTF-8

### DIFF
--- a/TX/Core/Downloaders/HttpParallelDownloader.cs
+++ b/TX/Core/Downloaders/HttpParallelDownloader.cs
@@ -263,7 +263,7 @@ namespace TX.Core.Downloaders
         public byte[] ToPersistentByteArray()
         {
             var progress = (CompositeProgress)Progress;
-            return Encoding.ASCII.GetBytes(JsonConvert.SerializeObject(
+            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(
                 new InnerCheckPoint()
                 {
                     TaskKey = DownloadTask.Key,
@@ -277,7 +277,7 @@ namespace TX.Core.Downloaders
         private void ApplyCheckPoint(byte[] checkPointByteArray)
         {
             var checkPoint = JsonConvert.DeserializeObject<InnerCheckPoint>(
-                Encoding.ASCII.GetString(checkPointByteArray));
+                Encoding.UTF8.GetString(checkPointByteArray));
             var progress = (CompositeProgress) Progress;
             Ensure.That(checkPoint.TaskKey, nameof(checkPoint.TaskKey))
                 .IsEqualTo(DownloadTask.Key);

--- a/TX/Core/Downloaders/TorrentDownloader.cs
+++ b/TX/Core/Downloaders/TorrentDownloader.cs
@@ -105,7 +105,7 @@ namespace TX.Core.Downloaders
             }
             catch (Exception) { }
 
-            return Encoding.ASCII.GetBytes(JsonConvert.SerializeObject(
+            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(
                 new InnerCheckPoint()
                 {
                     TaskKey = DownloadTask.Key,
@@ -295,7 +295,7 @@ namespace TX.Core.Downloaders
         private void ApplyCheckPoint(byte[] checkPointByteArray)
         {
             checkPoint = JsonConvert.DeserializeObject<InnerCheckPoint>(
-                Encoding.ASCII.GetString(checkPointByteArray));
+                Encoding.UTF8.GetString(checkPointByteArray));
             Ensure.That(checkPoint.TaskKey, nameof(checkPoint.TaskKey)).IsEqualTo(DownloadTask.Key);
 
             if (checkPoint.FastResumeData != null)

--- a/TX/Core/Models/Targets/TorrentTarget.cs
+++ b/TX/Core/Models/Targets/TorrentTarget.cs
@@ -15,21 +15,23 @@ namespace TX.Core.Models.Targets
 {
     public class TorrentTarget : AbstractTarget
     {
-        public TorrentTarget(byte[] torrentBytes, Uri displayedUri, string[] selectedFilePaths)
+        public TorrentTarget(byte[] torrentBytes, Uri displayedUri, string[] selectedFiles)
         {
             Ensure.That(torrentBytes, nameof(torrentBytes)).IsNotNull();
-            Ensure.That(selectedFilePaths, nameof(selectedFilePaths)).IsNotNull();
+            Ensure.That(selectedFiles, nameof(selectedFiles)).IsNotNull();
             Ensure.That(displayedUri, nameof(displayedUri)).IsNotNull();
 
             DisplayedUri = displayedUri;
             Torrent = Torrent.Load(torrentBytes);
 
             this.torrentBytes = torrentBytes;
-            this.selectedFilePaths = selectedFilePaths;
+            this.selectedFiles = selectedFiles;
             foreach (var file in Torrent.Files)
-                if (selectedFilePaths.Contains(file.Path))
+            {
+                if (selectedFiles.Contains(file.Path))
                     file.Priority = Priority.Normal;
                 else file.Priority = Priority.DoNotDownload;
+            }
         }
 
         [JsonIgnore]
@@ -40,7 +42,7 @@ namespace TX.Core.Models.Targets
         protected override string GetSuggestedName() => Torrent.Name;
 
         [JsonProperty]
-        private readonly string[] selectedFilePaths = null;
+        private readonly string[] selectedFiles = null;
         [JsonProperty]
         private readonly byte[] torrentBytes = null;
     }

--- a/TX/Core/Providers/LocalCacheManager.cs
+++ b/TX/Core/Providers/LocalCacheManager.cs
@@ -21,7 +21,7 @@ namespace TX.Core.Providers
             cacheItems.Clear();
             if (persistentData != null)
             {
-                string dataString = Encoding.ASCII.GetString(persistentData);
+                string dataString = Encoding.UTF8.GetString(persistentData);
                 var cacheArr = JsonConvert.DeserializeObject<
                     KeyValuePair<string, CacheItemInfo>[]>(dataString);
                 foreach (var kvp in cacheArr) cacheItems.Add(kvp.Key, kvp.Value);
@@ -36,7 +36,7 @@ namespace TX.Core.Providers
             lock (cacheItems)
             {
                 string dataString = JsonConvert.SerializeObject(cacheItems.ToArray());
-                return Encoding.ASCII.GetBytes(dataString);
+                return Encoding.UTF8.GetBytes(dataString);
             }
         }
 

--- a/TX/Core/TXCoreManager.cs
+++ b/TX/Core/TXCoreManager.cs
@@ -40,7 +40,7 @@ namespace TX.Core
 
                 if (checkPoint != null)
                 {
-                    var json = Encoding.ASCII.GetString(checkPoint);
+                    var json = Encoding.UTF8.GetString(checkPoint);
                     var checkPointObject = JsonConvert.DeserializeObject<InnerCheckPoint>(json,
                         new JsonSerializerSettings()
                         {
@@ -199,7 +199,7 @@ namespace TX.Core
         public byte[] ToPersistentByteArray()
         {
             D("Generating persistent byte array...");
-            return Encoding.ASCII.GetBytes(JsonConvert.SerializeObject(
+            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(
                 new InnerCheckPoint()
                 {
                     Tasks = Tasks.ToArray(),

--- a/TX/Core/Utils/UrlConverters.cs
+++ b/TX/Core/Utils/UrlConverters.cs
@@ -19,7 +19,7 @@ namespace TX.Core.Utils
                     "IsThunderProxy"
                 ).IsTrue();
                 if (!strUri.EndsWith('/')) strUri += '/';
-                string t = Encoding.ASCII.GetString(
+                string t = Encoding.UTF8.GetString(
                     Convert.FromBase64String(
                         strUri.Substring(10, strUri.Length - 11)
                     )


### PR DESCRIPTION
ASCII is adapted when reading or writing the database by mistake which causes failure decoding UTF-8 characters in our storage file. This should solve issue #42, that torrent targets deserialized from the database cannot obtain a correct to-be-downloaded file list, and remained a 0-byte target which is not accepted by the torrent downloader.