### PR TITLE
Framework for customization cache folder

### DIFF
--- a/TX/Core/Providers/LocalCacheManager.cs
+++ b/TX/Core/Providers/LocalCacheManager.cs
@@ -16,6 +16,11 @@ namespace TX.Core.Providers
 {
     public class LocalCacheManager : IPersistable
     {
+        public LocalCacheManager(StorageFolder cacheFolder)
+        {
+            this.cacheFolder = cacheFolder;
+        }
+
         public void Initialize(byte[] persistentData)
         {
             cacheItems.Clear();
@@ -46,8 +51,8 @@ namespace TX.Core.Providers
             {
                 Debug.WriteLine("[{0}] cleaning cache folder".AsFormat(
                     nameof(LocalCacheManager)));
-                var cacheFolder = ApplicationData.Current.LocalCacheFolder;
                 var items = await cacheFolder.GetItemsAsync();
+
                 List<IStorageItem> unused_items = null;
 
                 lock (cacheItems)
@@ -93,15 +98,13 @@ namespace TX.Core.Providers
                 string path = string.Empty;
                 if (isFolder)
                 {
-                    var folder = await ApplicationData.Current
-                        .LocalCacheFolder.CreateFolderAsync(
+                    var folder = await cacheFolder.CreateFolderAsync(
                         randomName, CreationCollisionOption.GenerateUniqueName);
                     path = folder.Path;
                 }
                 else
                 {
-                    var file = await ApplicationData.Current
-                        .LocalCacheFolder.CreateFileAsync(
+                    var file = await cacheFolder.CreateFileAsync(
                         randomName, CreationCollisionOption.GenerateUniqueName);
                     path = file.Path;
                 }
@@ -126,8 +129,7 @@ namespace TX.Core.Providers
             }
         }
 
-        private IStorageFile GetCacheFileForTask(
-            string token, string taskKey)
+        private IStorageFile GetCacheFileForTask(string token, string taskKey)
         {
             lock (cacheItems)
             {
@@ -150,8 +152,7 @@ namespace TX.Core.Providers
             }
         }
 
-        private IStorageFolder GetCacheFolderForTask(
-            string token, string taskKey)
+        private IStorageFolder GetCacheFolderForTask(string token, string taskKey)
         {
             lock (cacheItems)
             {
@@ -207,5 +208,6 @@ namespace TX.Core.Providers
 
         private readonly Dictionary<string, CacheItemInfo> cacheItems = 
             new Dictionary<string, CacheItemInfo>();
+        private StorageFolder cacheFolder = null;
     }
 }

--- a/TX/Core/TXCoreManager.cs
+++ b/TX/Core/TXCoreManager.cs
@@ -38,7 +38,7 @@ namespace TX.Core
             {
                 await LoadAnnounceUrlsAsync();
                 await InitializeDhtEngineAsync();
-                await InitializeCacheFolderAsync();
+                InitializeCacheFolder();
 
                 if (checkPoint != null)
                 {
@@ -85,6 +85,8 @@ namespace TX.Core
         public MonoTorrent.Client.ClientEngine TorrentEngine => torrentEngine;
 
         public IReadOnlyList<string> CustomAnnounceURLs => customAnnounceUrls;
+
+        public IStorageFolder CacheFolder => coreCacheManager.CacheFolder;
 
         public void RemoveHistory(DownloadHistory history) =>
             histories.Remove(history);
@@ -289,31 +291,10 @@ namespace TX.Core
             }
         }
 
-        private async Task InitializeCacheFolderAsync()
+        private void InitializeCacheFolder()
         {
-            StorageFolder cacheFolder = null;
-
-            try
-            {
-                if (!string.IsNullOrEmpty(settingEntries.CacheFolderToken))
-                {
-                    D($"Cache folder token <{settingEntries.CacheFolderToken}>");
-                    cacheFolder = await StorageApplicationPermissions
-                        .FutureAccessList.GetFolderAsync(
-                            settingEntries.CacheFolderToken);
-                }
-                else D("Cache folder token null or empty");
-            }
-            catch (Exception e) 
-            {
-                D($"Cache folder initialization failed: {e.Message}");
-            }
-
-            if (cacheFolder == null)
-                cacheFolder = ApplicationData.Current.LocalCacheFolder;
-
-            D($"Cache folder initialized: {cacheFolder.Path}");
-            coreCacheManager = new LocalCacheManager(cacheFolder);
+            coreCacheManager = new LocalCacheManager(
+                ApplicationData.Current.LocalCacheFolder);
             D("Core cache manager initialized");
         }
 

--- a/TX/MultilingualResources/TX.zh-Hans.xlf
+++ b/TX/MultilingualResources/TX.zh-Hans.xlf
@@ -148,14 +148,6 @@
           <source>Downloader Configurations</source>
           <target state="translated">下载器配置</target>
         </trans-unit>
-        <trans-unit id="SetPage_DownloadFolder_Button.Content" translate="yes" xml:space="preserve">
-          <source>Select Folder</source>
-          <target state="translated">选取文件夹</target>
-        </trans-unit>
-        <trans-unit id="SetPage_DownloadFolder_Title.Text" translate="yes" xml:space="preserve">
-          <source>Default Download Folder</source>
-          <target state="translated">默认下载文件夹</target>
-        </trans-unit>
         <trans-unit id="SetPage_Notifications_TaskCompletedToggleSwitch.Header" translate="yes" xml:space="preserve">
           <source>Task Completion Notification</source>
           <target state="translated">有任务完成时发送通知</target>
@@ -338,10 +330,6 @@ Create a task for downloading.</source>
           <source>Cache files that are no longer valid are automatically cleaned each time the application is closed. Manual cleanup is often unnecessary.</source>
           <target state="translated">失效的缓存文件将在每次应用程序被关闭时被自动清理。一般来说手动进行垃圾清理是不必要的。</target>
         </trans-unit>
-        <trans-unit id="SetPage_DownloadFolder_OpenButton.Content" translate="yes" xml:space="preserve">
-          <source>Open Current</source>
-          <target state="translated">打开文件夹</target>
-        </trans-unit>
         <trans-unit id="SetPage_BackgroundTask_BackgroundTaskToggleSwitch.Header" translate="yes" xml:space="preserve">
           <source>Enable Downloads in Background</source>
           <target state="translated">启用后台下载</target>
@@ -477,6 +465,14 @@ Create a task for downloading.</source>
         <trans-unit id="NewTaskPage_TorrentTeachingTip.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>Later</source>
           <target state="translated">下次一定</target>
+        </trans-unit>
+        <trans-unit id="SetPage_Folders_DownloadFolder_Subtitle.Text" translate="yes" xml:space="preserve">
+          <source>Download Folder</source>
+          <target state="translated">下载文件夹</target>
+        </trans-unit>
+        <trans-unit id="SetPage_Folders_Title.Text" translate="yes" xml:space="preserve">
+          <source>Folders</source>
+          <target state="translated">目录</target>
         </trans-unit>
       </group>
     </body>

--- a/TX/Resources/Strings/en-US/Resources.resw
+++ b/TX/Resources/Strings/en-US/Resources.resw
@@ -350,14 +350,11 @@
   <data name="SetPage_Downloader_Title.Text" xml:space="preserve">
     <value>Downloader Configurations</value>
   </data>
-  <data name="SetPage_DownloadFolder_Button.Content" xml:space="preserve">
-    <value>Select Folder</value>
+  <data name="SetPage_Folders_DownloadFolder_Subtitle.Text" xml:space="preserve">
+    <value>Download Folder</value>
   </data>
-  <data name="SetPage_DownloadFolder_OpenButton.Content" xml:space="preserve">
-    <value>Open Current</value>
-  </data>
-  <data name="SetPage_DownloadFolder_Title.Text" xml:space="preserve">
-    <value>Default Download Folder</value>
+  <data name="SetPage_Folders_Title.Text" xml:space="preserve">
+    <value>Folders</value>
   </data>
   <data name="SetPage_HTTP_Title.Text" xml:space="preserve">
     <value>HTTP/HTTPS</value>

--- a/TX/Resources/Strings/zh-Hans/Resources.resw
+++ b/TX/Resources/Strings/zh-Hans/Resources.resw
@@ -119,12 +119,6 @@
   <data name="SetPage_Downloader_Title.Text" xml:space="preserve">
     <value>下载器配置</value>
   </data>
-  <data name="SetPage_DownloadFolder_Button.Content" xml:space="preserve">
-    <value>选取文件夹</value>
-  </data>
-  <data name="SetPage_DownloadFolder_Title.Text" xml:space="preserve">
-    <value>默认下载文件夹</value>
-  </data>
   <data name="SetPage_Notifications_TaskCompletedToggleSwitch.Header" xml:space="preserve">
     <value>有任务完成时发送通知</value>
   </data>
@@ -259,9 +253,6 @@
   <data name="SetPage_CleanUp_GuideText.Text" xml:space="preserve">
     <value>失效的缓存文件将在每次应用程序被关闭时被自动清理。一般来说手动进行垃圾清理是不必要的。</value>
   </data>
-  <data name="SetPage_DownloadFolder_OpenButton.Content" xml:space="preserve">
-    <value>打开文件夹</value>
-  </data>
   <data name="SetPage_BackgroundTask_BackgroundTaskToggleSwitch.Header" xml:space="preserve">
     <value>启用后台下载</value>
   </data>
@@ -363,5 +354,11 @@
   </data>
   <data name="NewTaskPage_TorrentTeachingTip.CloseButtonContent" xml:space="preserve">
     <value>下次一定</value>
+  </data>
+  <data name="SetPage_Folders_DownloadFolder_Subtitle.Text" xml:space="preserve">
+    <value>下载文件夹</value>
+  </data>
+  <data name="SetPage_Folders_Title.Text" xml:space="preserve">
+    <value>目录</value>
   </data>
 </root>

--- a/TX/SetPage.xaml
+++ b/TX/SetPage.xaml
@@ -59,22 +59,41 @@
                               IsOn="{x:Bind SettingEntries.IsDarkModeEnabled, Mode=TwoWay}"/>
 
                 <!--Default Download Folder-->
-                <TextBlock x:Uid="SetPage_DownloadFolder_Title" Margin="0 0 0 16"
+                <TextBlock x:Uid="SetPage_Folders_Title" Margin="0 0 0 16"
                            Style="{ThemeResource TXPageSubtitleTextBlockStyle}"/>
-                <TextBlock x:Name="DefaultDownloadFolderPathTextBlock" 
-                           Style="{ThemeResource TXFilePathStyle}" Margin="0 0 0 16"/>
-                <StackPanel Orientation="Horizontal" Margin="0 0 0 24">
-                    <!--Select Folder-->
-                    <Button x:Name="DefaultDownloadFolderButton" x:Uid="SetPage_DownloadFolder_Button"
-                            Height="36" Width="160" Style="{ThemeResource ButtonRevealStyle}" Margin="0 0 8 0"
-                            Click="DefaultDownloadFolderButton_Click"/>
-                    <!--Open Folder-->
-                    <Button x:Name="OpenDownloadFolderButton" x:Uid="SetPage_DownloadFolder_OpenButton"
-                            Height="36" Width="160" Style="{ThemeResource ButtonRevealStyle}"
-                            Background="{ThemeResource SystemAccentColor}"
-                            Foreground="{ThemeResource SystemAltHighColor}"
-                            Click="OpenDownloadFolderButton_Click"/>
-                </StackPanel>
+                <Grid Margin="0 0 0 24">
+                    <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock x:Uid="SetPage_Folders_DownloadFolder_Subtitle"
+                               Style="{ThemeResource TXControlHeaderStyle}"
+                               Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"/>
+                    <TextBlock x:Name="DownloadFolderPathTextBlock" 
+                               Grid.Row="1" Grid.Column="0" Margin="0 0 8 0"
+                               Style="{ThemeResource TXFilePathStyle}"/>
+                    <AppBarButton x:Name="DownloadFolderEditButton" 
+                                  Grid.Row="0" Grid.Column="1" Grid.RowSpan="2"
+                                  Icon="Edit" Width="40" LabelPosition="Collapsed" 
+                                  VerticalAlignment="Top" Style="{ThemeResource AppBarButtonRevealStyle}"
+                                  Click="DownloadFolderEditButton_Click"/>
+                    <AppBarButton x:Name="DownloadFolderOpenButton"
+                                  Grid.Row="0" Grid.Column="2" Grid.RowSpan="2"
+                                  Width="40" LabelPosition="Collapsed"
+                                  VerticalAlignment="Top" Style="{ThemeResource AppBarButtonRevealStyle}"
+                                  Click="DownloadFolderOpenButton_Click">
+                        <AppBarButton.Icon>
+                            <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="&#xE8DA;" />
+                        </AppBarButton.Icon>
+                    </AppBarButton>
+                </Grid>
 
                 <!--Downloader Configurations-->
                 <TextBlock x:Uid="SetPage_Downloader_Title" Margin="0 0 0 16"

--- a/TX/Utils/Settings.cs
+++ b/TX/Utils/Settings.cs
@@ -33,15 +33,6 @@ namespace TX.Utils
             set { SetValue(nameof(DownloadsFolderToken), value); }
         }
 
-        /// <summary>
-        /// Token of the cache folder (in the FutureAccessList).
-        /// </summary>
-        public string CacheFolderToken
-        {
-            get { return TryGetValue<string>(nameof(CacheFolderToken), null); }
-            set { SetValue(nameof(CacheFolderToken), value); }
-        }
-
         #endregion
 
         #region Downloader Settings

--- a/TX/Utils/Settings.cs
+++ b/TX/Utils/Settings.cs
@@ -33,6 +33,15 @@ namespace TX.Utils
             set { SetValue(nameof(DownloadsFolderToken), value); }
         }
 
+        /// <summary>
+        /// Token of the cache folder (in the FutureAccessList).
+        /// </summary>
+        public string CacheFolderToken
+        {
+            get { return TryGetValue<string>(nameof(CacheFolderToken), null); }
+            set { SetValue(nameof(CacheFolderToken), value); }
+        }
+
         #endregion
 
         #region Downloader Settings


### PR DESCRIPTION
For now, there's still some not available to customize the cache folder, for traditional file IO API used by our parallel downloader and MonoTorrent downloader kernel doesn't support the access limit of the UWP file system. This PR only cleans the code and adds interfaces for getting and setting the cache folder.